### PR TITLE
Mirror of google error-prone PR IssueNumber 1874

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
+++ b/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java
@@ -339,7 +339,12 @@ public class ASTHelpers {
           .anyMatch(t -> t.kind() == TokenKind.PLUS);
     }
     if (expression instanceof UnaryTree) {
-      return false;
+      Tree parent = state.getPath().getParentPath().getLeaf();
+      if (!(parent instanceof MemberSelectTree)) {
+        return false;
+      }
+      // eg. (i++).toString();
+      return stripParentheses(((MemberSelectTree) parent).getExpression()).equals(expression);
     }
     return true;
   }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryParenthesesTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/UnnecessaryParenthesesTest.java
@@ -134,4 +134,50 @@ public class UnnecessaryParenthesesTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void unaryPostFixParenthesesNotNeeded() {
+    testHelper
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  void print(Integer i) {",
+            "    int j = (i++) + 2;",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "class Test {",
+            "  void print(Integer i) {",
+            "    int j = i++ + 2;",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void unaryPostFixParenthesesNeeded() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void print(Integer i) {",
+            "    (i++).toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  public void unaryPreFixParenthesesNeeded() {
+    helper
+        .addSourceLines(
+            "Test.java",
+            "class Test {",
+            "  void print(Integer i) {",
+            "    (++i).toString();",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
Mirror of google error-prone PR IssueNumber 1874
Don't flag expressions with postfix operations for UnnecessaryParentheses

