### PR TITLE
Mirror of google error-prone PR IssueNumber 1856

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -1073,9 +1073,9 @@ public class SuggestedFixes {
     Optional<ExpressionTree> maybeExistingArgument = findArgument(annotation, parameterName);
     if (!maybeExistingArgument.isPresent()) {
       return SuggestedFix.builder()
-          .prefixWith(
-              annotation.getArguments().get(0),
-              parameterName + " = " + newArgument(newValues) + ", ");
+          .postfixWith(
+              getLast(annotation.getArguments()),
+              ", " + parameterName + " = " + newArgument(newValues));
     }
 
     ExpressionTree existingArgument = maybeExistingArgument.get();
@@ -1114,9 +1114,9 @@ public class SuggestedFixes {
     Optional<ExpressionTree> maybeExistingArgument = findArgument(annotation, parameterName);
     if (!maybeExistingArgument.isPresent()) {
       return SuggestedFix.builder()
-          .prefixWith(
-              annotation.getArguments().get(0),
-              parameterName + " = " + newArgument(newValues) + ", ");
+          .postfixWith(
+              getLast(annotation.getArguments()),
+              ", " + parameterName + " = " + newArgument(newValues));
     }
 
     ExpressionTree existingArgument = maybeExistingArgument.get();


### PR DESCRIPTION
Mirror of google error-prone PR IssueNumber 1856
Add values to annotations at the end

instead of at the beginning; it's cleaner.

